### PR TITLE
wasm: Bump wasmedge from 0.11.0 to 0.11.2 in the testing environment

### DIFF
--- a/tests/wasmedge-build/Dockerfile
+++ b/tests/wasmedge-build/Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:rawhide
-ARG WASM_EDGE_VERSION="0.11.0"
+ARG WASM_EDGE_VERSION="0.11.2"
 
 # Install the deps for building crun
 RUN dnf update -y && dnf install -y make python git gcc automake autoconf libcap-devel \


### PR DESCRIPTION
Signed-off-by: hydai <hydai@secondstate.io>